### PR TITLE
[RL78 patch 1] Recognize RL78 in triple parsing code.

### DIFF
--- a/llvm/include/llvm/TargetParser/Triple.h
+++ b/llvm/include/llvm/TargetParser/Triple.h
@@ -104,6 +104,7 @@ public:
     wasm64,         // WebAssembly with 64-bit pointers
     renderscript32, // 32-bit RenderScript
     renderscript64, // 64-bit RenderScript
+    rl78,           // Renesas RL78
     ve,             // NEC SX-Aurora Vector Engine
     LastArchType = ve
   };

--- a/llvm/lib/TargetParser/Triple.cpp
+++ b/llvm/lib/TargetParser/Triple.cpp
@@ -63,6 +63,7 @@ StringRef Triple::getArchTypeName(ArchType Kind) {
   case renderscript64: return "renderscript64";
   case riscv32:        return "riscv32";
   case riscv64:        return "riscv64";
+  case rl78:           return "rl78";
   case shave:          return "shave";
   case sparc:          return "sparc";
   case sparcel:        return "sparcel";
@@ -218,6 +219,8 @@ StringRef Triple::getArchTypePrefix(ArchType Kind) {
 
   case riscv32:
   case riscv64:     return "riscv";
+
+  case rl78:        return "rl78";
 
   case ve:          return "ve";
   case csky:        return "csky";
@@ -445,6 +448,7 @@ Triple::ArchType Triple::getArchTypeForLLVMName(StringRef Name) {
     .Case("wasm64", wasm64)
     .Case("renderscript32", renderscript32)
     .Case("renderscript64", renderscript64)
+    .Case("rl78", rl78)
     .Case("ve", ve)
     .Case("csky", csky)
     .Case("loongarch32", loongarch32)
@@ -586,6 +590,7 @@ static Triple::ArchType parseArch(StringRef ArchName) {
           .Case("lanai", Triple::lanai)
           .Case("renderscript32", Triple::renderscript32)
           .Case("renderscript64", Triple::renderscript64)
+          .Case("rl78", Triple::rl78)          
           .Case("shave", Triple::shave)
           .Case("ve", Triple::ve)
           .Case("wasm32", Triple::wasm32)
@@ -916,6 +921,7 @@ static Triple::ObjectFormatType getDefaultFormat(const Triple &T) {
   case Triple::renderscript64:
   case Triple::riscv32:
   case Triple::riscv64:
+  case Triple::rl78:
   case Triple::shave:
   case Triple::sparc:
   case Triple::sparcel:
@@ -1582,6 +1588,7 @@ unsigned Triple::getArchPointerBitWidth(llvm::Triple::ArchType Arch) {
 
   case llvm::Triple::avr:
   case llvm::Triple::msp430:
+  case llvm::Triple::rl78:
     return 16;
 
   case llvm::Triple::aarch64_32:
@@ -1669,6 +1676,7 @@ Triple Triple::get32BitArchVariant() const {
   case Triple::bpfeb:
   case Triple::bpfel:
   case Triple::msp430:
+  case Triple::rl78:
   case Triple::systemz:
   case Triple::ve:
     T.setArch(UnknownArch);
@@ -1753,6 +1761,7 @@ Triple Triple::get64BitArchVariant() const {
   case Triple::m68k:
   case Triple::msp430:
   case Triple::r600:
+  case Triple::rl78:
   case Triple::shave:
   case Triple::sparcel:
   case Triple::tce:
@@ -1844,6 +1853,7 @@ Triple Triple::getBigEndianArchVariant() const {
   case Triple::renderscript64:
   case Triple::riscv32:
   case Triple::riscv64:
+  case Triple::rl78:
   case Triple::shave:
   case Triple::spir64:
   case Triple::spir:
@@ -1951,6 +1961,7 @@ bool Triple::isLittleEndian() const {
   case Triple::renderscript64:
   case Triple::riscv32:
   case Triple::riscv64:
+  case Triple::rl78:
   case Triple::shave:
   case Triple::sparcel:
   case Triple::spir64:

--- a/llvm/unittests/TargetParser/TripleTest.cpp
+++ b/llvm/unittests/TargetParser/TripleTest.cpp
@@ -1175,6 +1175,18 @@ TEST(TripleTest, ParsedIDs) {
   EXPECT_EQ(Triple::Linux, T.getOS());
   EXPECT_EQ(Triple::PAuthTest, T.getEnvironment());
 
+  T = Triple("rl78");
+  EXPECT_EQ(Triple::rl78, T.getArch());
+  EXPECT_EQ(Triple::UnknownVendor, T.getVendor());
+  EXPECT_EQ(Triple::UnknownOS, T.getOS());
+  EXPECT_EQ(Triple::UnknownEnvironment, T.getEnvironment());
+
+  T = Triple("rl78-unknown-unknown");
+  EXPECT_EQ(Triple::rl78, T.getArch());
+  EXPECT_EQ(Triple::UnknownVendor, T.getVendor());
+  EXPECT_EQ(Triple::UnknownOS, T.getOS());
+  EXPECT_EQ(Triple::UnknownEnvironment, T.getEnvironment());
+
   T = Triple("huh");
   EXPECT_EQ(Triple::UnknownArch, T.getArch());
 }
@@ -1565,6 +1577,11 @@ TEST(TripleTest, BitWidthChecks) {
   EXPECT_FALSE(T.isArch16Bit());
   EXPECT_TRUE(T.isArch32Bit());
   EXPECT_FALSE(T.isArch64Bit());
+
+  T.setArch(Triple::rl78);
+  EXPECT_TRUE(T.isArch16Bit());
+  EXPECT_FALSE(T.isArch32Bit());
+  EXPECT_FALSE(T.isArch64Bit());
 }
 
 TEST(TripleTest, BitWidthArchVariants) {
@@ -1767,6 +1784,11 @@ TEST(TripleTest, BitWidthArchVariants) {
   T.setArch(Triple::xtensa);
   EXPECT_EQ(Triple::xtensa, T.get32BitArchVariant().getArch());
   EXPECT_EQ(Triple::UnknownArch, T.get64BitArchVariant().getArch());
+
+  T.setArch(Triple::rl78);
+  EXPECT_TRUE(T.isLittleEndian());
+  EXPECT_EQ(Triple::UnknownArch, T.getBigEndianArchVariant().getArch());
+  EXPECT_EQ(Triple::rl78, T.getLittleEndianArchVariant().getArch());
 }
 
 TEST(TripleTest, EndianArchVariants) {


### PR DESCRIPTION
Hello all,

I'm sharing an initial set of patches that adds LLVM backend for RL78 architecture.
I'll prepare the patches incrementally, in a similar order to Xtensa.
I've done this once before (https://reviews.llvm.org/D150693).
However, I took a break to update the LLVM version I was using as I was stuck with an old version so porting patches to latest sources seemed dificult.
Now my patches should in quicker succession.


Thank you!